### PR TITLE
feat: the last bug

### DIFF
--- a/backend/src/modulos/cursos/repositorio.ts
+++ b/backend/src/modulos/cursos/repositorio.ts
@@ -211,6 +211,16 @@ export async function coordenadorTemCurso(coordenadorId: string, cursoId: string
   return (res.rowCount ?? 0) > 0;
 }
 
+// Vincula um coordenador a um curso (idempotente)
+export async function vincularCoordenadorAoCurso(coordenadorId: string, cursoId: string): Promise<void> {
+  await pool.query(
+    `INSERT INTO coordenadores_cursos (coordenador_id, curso_id)
+     VALUES ($1, $2)
+     ON CONFLICT DO NOTHING`,
+    [coordenadorId, cursoId],
+  );
+}
+
 // Lista os estudantes vinculados a um curso (somente leitura)
 export async function listarAlunosDoCurso(cursoId: string): Promise<AlunoDoCurso[]> {
   const res = await pool.query<AlunoDoCurso>(

--- a/backend/src/modulos/usuarios/rotas.ts
+++ b/backend/src/modulos/usuarios/rotas.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcryptjs';
 import { autenticar } from '../../middleware/autenticacao';
 import { exigirPerfil } from '../../middleware/autorizacao';
 import * as repositorio from './repositorio';
+import { vincularCoordenadorAoCurso } from '../cursos/repositorio';
 import { tratarErro } from '../../utils/erros';
 
 const router = Router();
@@ -189,6 +190,10 @@ router.post('/', autenticar, exigirPerfil('admin'), async (req, res) => {
       curso_id: curso_id || null,
     });
 
+    if (perfil === 'coordenador' && curso_id) {
+      await vincularCoordenadorAoCurso(usuario.id, curso_id);
+    }
+
     res.status(201).json(usuario);
   } catch (err: unknown) {
     tratarErro(res, err, 'usuarios/criar');
@@ -245,6 +250,10 @@ router.put('/:id', autenticar, exigirPerfil('admin'), async (req, res) => {
     if (!usuario) {
       res.status(404).json({ erro: 'Usuário não encontrado' });
       return;
+    }
+
+    if (usuario.perfil === 'coordenador' && usuario.curso_id) {
+      await vincularCoordenadorAoCurso(usuario.id, usuario.curso_id);
     }
 
     res.json(usuario);

--- a/infra/migrations/005_backfill_coordenadores_cursos.sql
+++ b/infra/migrations/005_backfill_coordenadores_cursos.sql
@@ -1,0 +1,10 @@
+-- Migration 005: Re-sincroniza coordenadores_cursos para coordenadores
+-- que possuem curso_id em usuarios mas não têm entrada na tabela de vínculo.
+--
+-- Aplicar:
+--   psql -U postgres -d valida_db -f infra/migrations/005_backfill_coordenadores_cursos.sql
+
+INSERT INTO coordenadores_cursos (coordenador_id, curso_id)
+SELECT id, curso_id FROM usuarios
+WHERE perfil = 'coordenador' AND curso_id IS NOT NULL
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
This pull request introduces functionality to ensure that all coordinators with an associated course in the `usuarios` table are properly linked in the `coordenadores_cursos` join table. It adds both a migration to backfill missing links and updates the application logic to maintain this relationship when creating or updating users. The main changes are grouped below:

**Database Migration & Data Consistency**

* Added migration `005_backfill_coordenadores_cursos.sql` to insert missing coordinator-course links for coordinators with a `curso_id` in the `usuarios` table, ensuring data consistency between the two tables.

**Repository Layer Enhancements**

* Added the `vincularCoordenadorAoCurso` function to `cursos/repositorio.ts`, providing an idempotent way to link a coordinator to a course in the `coordenadores_cursos` table.

**API Logic Updates**

* Modified user creation (`POST /usuarios`) to automatically link a new coordinator to a course in `coordenadores_cursos` if both `perfil` is 'coordenador' and `curso_id` is provided.
* Modified user update (`PUT /usuarios/:id`) to ensure any updated coordinator with a `curso_id` is also linked in `coordenadores_cursos`.
* Imported the new linking function in `usuarios/rotas.ts` to support the above logic.…ação para re-sincronização